### PR TITLE
enable armclient to deal with Azure German Cloud

### DIFF
--- a/azureclient.go
+++ b/azureclient.go
@@ -19,8 +19,12 @@ type AzureClient struct {
 }
 
 func NewAzureClient(config *Config, environment *Environment) *AzureClient {
+
+	httpClient := &http.Client{}
+	httpClient.Transport = &environment.httpTransport
+
 	return &AzureClient{
-		client:      &http.Client{},
+		client:      httpClient,
 		config:      config,
 		environment: environment,
 		accessToken: "",
@@ -124,7 +128,11 @@ func (azureClient *AzureClient) sendHttpMessage(method string, url string) *http
 func (azureClient *AzureClient) getAzureResources(maxContinuation int) []ArmResource {
 	// Invoke Azure Resource Manager resource cache API to find all Azure resources on the subscription
 	armResourceSlice := make([]ArmResource, 0)
-	targetUrl := fmt.Sprintf("/subscriptions/%s/resources?api-version=2017-08-01", azureClient.config.Credentials.SubscriptionID)
+	targetUrl := fmt.Sprintf(
+			"/subscriptions/%s/resources?api-version=%s",
+			azureClient.config.Credentials.SubscriptionID,
+			azureClient.environment.apiVersion,
+		)
 
 	// Follow nextLink continuation tokens
 	i := 0

--- a/environment.go
+++ b/environment.go
@@ -1,31 +1,52 @@
 package main
 
 import (
+	"crypto/tls"
 	"fmt"
 	"log"
+	"net/http"
 	"strings"
 )
 
 type Environment struct {
 	aadLoginUrl string
+	apiVersion  string
 	armUrl      string
+	httpTransport http.Transport
 }
 
 const (
 	PublicEnvironmentName = "Public"
+	GermanEnvironmentName = "AzureGermanCloud"
 )
 
 var (
 	// Public Azure
 	publicAzureEnvironment = Environment{
-		aadLoginUrl: "https://login.microsoftonline.com",
-		armUrl:      "https://management.azure.com",
+		aadLoginUrl:   "https://login.microsoftonline.com",
+		apiVersion:    "2017-08-01",
+		armUrl:        "https://management.azure.com",
+		httpTransport: http.Transport{},
+	}
+
+	germanAzureEnvironment = Environment{
+		aadLoginUrl: "https://login.microsoftonline.de",
+		apiVersion: "2016-06-01",
+		armUrl:      "https://management.microsoftazure.de",
+		httpTransport: http.Transport{
+			TLSClientConfig: &tls.Config{
+				MaxVersion:    tls.VersionTLS11,
+				Renegotiation: tls.RenegotiateFreelyAsClient,
+			},
+		},
 	}
 )
 
 func getCurrentEnvironment(environmentName string) *Environment {
 	if strings.EqualFold(environmentName, PublicEnvironmentName) {
 		return &publicAzureEnvironment
+	} else if strings.EqualFold(environmentName, GermanEnvironmentName) {
+		return &germanAzureEnvironment
 	}
 
 	log.Fatalf("Unknown environment: %s", environmentName)


### PR DESCRIPTION
In the AzureGermany environment, REST-endpoints are reachable under different URLs. In addition, the APIs are older and require different connection paramters.

Defining separate environments with different parameters allos armclient to operate against other Microsoft Cloud environments as well.